### PR TITLE
bump jsonschema range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 requires = [
     "python-dateutil>=2.8,<2.9",
-    "jsonschema<3.2,>=3.0",
+    "jsonschema<4.0,>=3.0",
     'dataclasses>=0.6,<0.9;python_version<"3.7"',
 ]
 


### PR DESCRIPTION
I don't know if this is going to fail or not, but I just wanted to try and move the conversation forward for https://github.com/dbt-labs/hologram/issues/43. it would be good to know from the maintainers, if there was a specific reason behind the strict range and if we can fix that