### PR TITLE
Change from python-dateutil to types-python-dateutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 requires = [
-    "python-dateutil>=2.8,<2.9",
+    "types-python-dateutil>=2.8,<2.9",
     "jsonschema<4.0,>=3.0",
     'dataclasses>=0.6,<0.9;python_version<"3.7"',
 ]


### PR DESCRIPTION
We aren't running CI on this often (last time was 7 months ago) and there seems to be a change with using `python-dateutil` and instead the CI fails saying use `types-python-dateutil`

CI failure: https://app.circleci.com/pipelines/github/dbt-labs/hologram/158/workflows/130bcf0c-3f8e-43ad-be93-e6cfa58fc2e3/jobs/315

New package details explain its a stub package for the `python-dateutil` package: https://pypi.org/project/types-python-dateutil/

I ran locally and it builds and passes `pytest` with this