### PR TITLE
Use default_factory in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ class Bar(JsonSchemaMixin):
 class Baz(JsonSchemaMixin):
     """Type with nested default value"""
 
-    a: Point = field(default=Point(0.0, 0.0))
+    a: Point = field(default_factory=lambda: Point(0.0, 0.0))
 
 
 @dataclass


### PR DESCRIPTION
Hi! Thanks for `hologram`!

This updates to use the modern dataclasses API, which doesn't allow mutable `default` arguments.

See https://github.com/conda-forge/hologram-feedstock/pull/4