### PR TITLE
remove top pin for jsonschema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 requires = [
     "python-dateutil>=2.8,<2.9",
-    "jsonschema<4.0,>=3.0",
+    "jsonschema>=3.0",
     'dataclasses>=0.6,<0.9;python_version<"3.7"',
 ]
 


### PR DESCRIPTION
Hi! Thanks for `hologram`!

This removes the top pin for `jsonschema`. Under test, this passes with ~90% coverage over on https://github.com/conda-forge/hologram-feedstock/pull/4 where this pin is becoming problematic for downstreams.

See also #50.